### PR TITLE
Fix default lookup of s3 region based upon dns lookup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,12 +33,13 @@ scriptedLaunchOpts ++= Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 
 crossSbtVersions := Vector("0.13.16", "1.1.0")
 
-val amazonSDKVersion = "1.12.99"
+val amazonSDKVersion = "1.12.129"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % amazonSDKVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % amazonSDKVersion,
-  "org.apache.ivy" % "ivy" % "2.4.0"
+  "org.apache.ivy" % "ivy" % "2.4.0",
+  "org.scalatest" %% "scalatest" % "3.2.10" % Test
 )
 
 // Tell the sbt-release plugin to use publishSigned

--- a/src/test/scala/fm/sbt/S3URLHandlerTest.scala
+++ b/src/test/scala/fm/sbt/S3URLHandlerTest.scala
@@ -1,0 +1,20 @@
+package fm.sbt
+
+import org.scalatest.PrivateMethodTester
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class S3URLHandlerTest extends AnyFunSuite with Matchers with PrivateMethodTester {
+  test("getDNSAliases") {
+    val getDNSAliasesMethod = PrivateMethod[Seq[String]]('getDNSAliases)
+    S3URLHandler invokePrivate getDNSAliasesMethod("maven.custom") shouldBe Seq("s3-w.us-east-1.amazonaws.com.", "s3-1-w.amazonaws.com.")
+    S3URLHandler invokePrivate getDNSAliasesMethod("acloudguru1234") shouldBe Seq("s3-us-west-2-w.amazonaws.com.")
+    S3URLHandler invokePrivate getDNSAliasesMethod("") shouldBe Nil
+  }
+
+  test("getRegionNameFromDNS") {
+    S3URLHandler.getRegionNameFromDNS("maven.custom") shouldBe Some("us-east-1")
+    S3URLHandler.getRegionNameFromDNS("acloudguru1234") shouldBe Some("us-west-2")
+  }
+}
+


### PR DESCRIPTION
This fixes these errors that can pop up:

```
com.amazonaws.SdkClientException: Failed to connect to service endpoint: 
	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:100)
	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:70)
	at com.amazonaws.internal.InstanceMetadataServiceResourceFetcher.readResource(InstanceMetadataServiceResourceFetcher.java:75)
	at com.amazonaws.internal.EC2ResourceFetcher.readResource(EC2ResourceFetcher.java:66)
	at com.amazonaws.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:407)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:376)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:372)
	at com.amazonaws.util.EC2MetadataUtils.getEC2InstanceRegion(EC2MetadataUtils.java:287)
	at com.amazonaws.regions.Regions.getCurrentRegion(Regions.java:109)
	at fm.sbt.S3URLHandler.$anonfun$getRegion$2(S3URLHandler.scala:396)
	at scala.Option.orElse(Option.scala:447)
	at fm.sbt.S3URLHandler.getRegion(S3URLHandler.scala:396)
	at fm.sbt.S3URLHandler.getClientBucketAndKey(S3URLHandler.scala:255)
	at fm.sbt.S3URLHandler.getURLInfo(S3URLHandler.scala:269)
	at fm.sbt.S3URLHandler.getURLInfo(S3URLHandler.scala:213)
	at org.apache.ivy.util.url.URLHandlerDispatcher.getURLInfo(URLHandlerDispatcher.java:66)
	at org.apache.ivy.plugins.repository.url.URLResource.init(URLResource.java:65)
	at org.apache.ivy.plugins.repository.url.URLResource.exists(URLResource.java:81)
	at org.apache.ivy.plugins.repository.url.URLRepository.put(URLRepository.java:74)
	at sbt.internal.librarymanagement.ConvertResolver$LocalIfFileRepo.put(ConvertResolver.scala:368)
	at org.apache.ivy.plugins.repository.AbstractRepository.put(AbstractRepository.java:130)
	at sbt.internal.librarymanagement.ConvertResolver$ChecksumFriendlyURLResolver.put(ConvertResolver.scala:118)
	at sbt.internal.librarymanagement.ConvertResolver$ChecksumFriendlyURLResolver.put$(ConvertResolver.scala:105)
	at sbt.internal.librarymanagement.ConvertResolver$$anonfun$defaultConvert$lzycompute$1$PluginCapableResolver$1.put(ConvertResolver.scala:165)
	at org.apache.ivy.plugins.resolver.RepositoryResolver.publish(RepositoryResolver.java:216)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$5(IvyActions.scala:504)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.util.Try$.apply(Try.scala:213)
	at sbt.internal.librarymanagement.IvyUtil$.retryWithBackoff(IvyUtil.scala:22)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$4(IvyActions.scala:503)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$4$adapted(IvyActions.scala:501)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at sbt.internal.librarymanagement.IvyActions$.publish(IvyActions.scala:501)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$3(IvyActions.scala:143)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at sbt.internal.librarymanagement.IvyActions$.withChecksums(IvyActions.scala:157)
	at sbt.internal.librarymanagement.IvyActions$.withChecksums(IvyActions.scala:150)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$1(IvyActions.scala:143)
	at sbt.internal.librarymanagement.IvyActions$.$anonfun$publish$1$adapted(IvyActions.scala:133)
	at sbt.internal.librarymanagement.IvySbt$Module.$anonfun$withModule$1(Ivy.scala:251)
	at sbt.internal.librarymanagement.IvySbt.$anonfun$withIvy$1(Ivy.scala:215)
	at sbt.internal.librarymanagement.IvySbt.sbt$internal$librarymanagement$IvySbt$$action$1(Ivy.scala:77)
	at sbt.internal.librarymanagement.IvySbt$$anon$1.call(Ivy.scala:87)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:113)
	at xsbt.boot.Locks$GlobalLock.withChannelRetries$1(Locks.scala:91)
	at xsbt.boot.Locks$GlobalLock.$anonfun$withFileLock$1(Locks.scala:119)
	at xsbt.boot.Using$.withResource(Using.scala:12)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.withFileLock(Locks.scala:119)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:71)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:59)
	at xsbt.boot.Locks$.apply0(Locks.scala:47)
	at xsbt.boot.Locks$.apply(Locks.scala:36)
	at sbt.internal.librarymanagement.IvySbt.withDefaultLogger(Ivy.scala:87)
	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:209)
	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:206)
	at sbt.internal.librarymanagement.IvySbt$Module.withModule(Ivy.scala:250)
	at sbt.internal.librarymanagement.IvyActions$.publish(IvyActions.scala:133)
	at sbt.Classpaths$.$anonfun$publishTask$4(Defaults.scala:3544)
	at sbt.Classpaths$.$anonfun$publishTask$4$adapted(Defaults.scala:3537)
	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
	at sbt.Execute.work(Execute.scala:291)
	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.net.SocketTimeoutException: connect timed out
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
	at sun.net.www.http.HttpClient.New(HttpClient.java:339)
	at sun.net.www.http.HttpClient.New(HttpClient.java:357)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1226)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1205)
	at sun.net.www.protocol.http.HttpURLConnection$6.run(HttpURLConnection.java:1046)
	at sun.net.www.protocol.http.HttpURLConnection$6.run(HttpURLConnection.java:1044)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.AccessController.doPrivilegedWithCombiner(AccessController.java:784)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1043)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:990)
	at com.amazonaws.internal.ConnectionUtils.connectToEndpoint(ConnectionUtils.java:95)
	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:80)
	... 79 more

[info] S3URLHandler - Created S3 Client for bucket: evenfinancial and region: us-west-2
```