### PR TITLE
Fix default lookup of s3 region based upon dns lookup and add tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ val amazonSDKVersion = "1.12.99"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % amazonSDKVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % amazonSDKVersion,
-  "org.apache.ivy" % "ivy" % "2.4.0"
+  "org.apache.ivy" % "ivy" % "2.4.0",
+  "org.scalatest" %% "scalatest" % "3.2.10" % Test
 )
 
 // Tell the sbt-release plugin to use publishSigned

--- a/src/main/scala/fm/sbt/S3URLHandler.scala
+++ b/src/main/scala/fm/sbt/S3URLHandler.scala
@@ -16,7 +16,7 @@
 package fm.sbt
 
 import java.io.{File, FileInputStream, InputStream}
-import java.net.{InetAddress, URI, URL}
+import java.net.{URI, URL}
 import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
 import com.amazonaws.ClientConfiguration
@@ -29,6 +29,10 @@ import com.amazonaws.services.securitytoken.{AWSSecurityTokenService, AWSSecurit
 import com.amazonaws.services.securitytoken.model.{AssumeRoleRequest, AssumeRoleResult}
 import org.apache.ivy.util.url.URLHandler
 import org.apache.ivy.util.{CopyProgressEvent, CopyProgressListener, Message}
+
+import javax.naming.{Context, NamingException}
+import javax.naming.directory.InitialDirContext
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.Try
 import scala.util.matching.Regex
@@ -188,6 +192,38 @@ object S3URLHandler {
     )
 
     new AWSCredentialsProviderChain((roleBasedProviders ++ basicProviders): _*)
+  }
+
+  def getRegionNameFromDNS(bucket: String): Option[String] = {
+    // maven.custom.s3.amazonaws.com. 21600 IN	CNAME	s3-1-w.amazonaws.com.
+    //           s3-1-w.amazonaws.com.	39	IN	CNAME	s3-w.us-east-1.amazonaws.com.
+    getDNSAliases(bucket).flatMap { RegionMatcher.findFirstIn(_) }.headOption
+  }
+
+  private[this] val dnsContext: InitialDirContext = {
+    val env: Properties = new Properties()
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory")
+    new InitialDirContext(env)
+  }
+
+  private def getDNSAliases(bucket: String): Seq[String] = {
+    val bucketHostname = bucket + ".s3.amazonaws.com"
+
+    @tailrec def impl(host: String, matches: Seq[String]): Seq[String] = {
+      val cname: Option[String] = try {
+        val attrs = dnsContext.getAttributes(host, Array("CNAME"))
+        Option(attrs.get("CNAME"))
+          .flatMap{ attr => Option(attr.get) }
+          .collectFirst { case host: String => host }
+      } catch {
+        case _: NamingException => None
+      }
+
+      if (cname.isEmpty || cname.exists{ matches.contains(_) }) matches
+      else impl(cname.get, cname.get +: matches)
+    }
+
+    impl(bucketHostname, Nil)
   }
 }
 
@@ -409,15 +445,7 @@ final class S3URLHandler extends URLHandler {
     // We'll try the AmazonS3URI parsing first then fallback to our RegionMatcher
     getAmazonS3URI(url).map{ _.getRegion }.flatMap{ Option(_) } orElse RegionMatcher.findFirstIn(url.toString)
   }
-  
-  def getRegionNameFromDNS(bucket: String): Option[String] = {
-    // This gives us something like s3-us-west-2-w.amazonaws.com which must have changed
-    // at some point because the region from that hostname is no longer parsed by AmazonS3URI
-    val canonicalHostName: String = InetAddress.getByName(bucket+".s3.amazonaws.com").getCanonicalHostName()
-    
-    // So we use our regex based RegionMatcher to try and extract the region since AmazonS3URI doesn't work
-    RegionMatcher.findFirstIn(canonicalHostName)
-  }
+
 
   // Not used anymore since the AmazonS3ClientBuilder requires the region during construction
 //  def getRegionNameFromService(bucket: String, client: AmazonS3): Option[String] = {

--- a/src/test/scala/fm/sbt/S3URLHandlerTest.scala
+++ b/src/test/scala/fm/sbt/S3URLHandlerTest.scala
@@ -1,0 +1,19 @@
+package fm.sbt
+
+import org.scalatest.PrivateMethodTester
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class S3URLHandlerTest extends AnyFunSuite with Matchers with PrivateMethodTester {
+  test("getDNSAliases") {
+    val getDNSAliasesMethod = PrivateMethod[Seq[String]]('getDNSAliases)
+    S3URLHandler invokePrivate getDNSAliasesMethod("maven.custom") shouldBe Seq("s3-w.us-east-1.amazonaws.com.", "s3-1-w.amazonaws.com.")
+    S3URLHandler invokePrivate getDNSAliasesMethod("acloudguru1234") shouldBe Seq("s3-us-west-2-w.amazonaws.com.")
+    S3URLHandler invokePrivate getDNSAliasesMethod("") shouldBe Nil
+  }
+
+  test("getRegionNameFromDNS") {
+    S3URLHandler.getRegionNameFromDNS("maven.custom") shouldBe Some("us-east-1")
+    S3URLHandler.getRegionNameFromDNS("acloudguru1234") shouldBe Some("us-west-2")
+  }
+}


### PR DESCRIPTION
Addresses suppressing this warning (when ran in non-ec2 environments) due to `getRegionNameFromDNS` failing.


```
[info] [info] S3URLHandler - Looking up AWS Credentials for bucket: maven.custom ...
[info] [info] S3URLHandler - Using AWS Access Key Id: test for bucket: maven.custom
[error] Jan 03, 2022 5:20:05 PM com.amazonaws.util.EC2MetadataUtils getItems
[error] WARNING: Unable to retrieve the requested metadata (/latest/dynamic/instance-identity/document). The requested metadata is not found at http://169.254.169.254/latest/dynamic/instance-identity/document
[error] com.amazonaws.SdkClientException: The requested metadata is not found at http://169.254.169.254/latest/dynamic/instance-identity/document
[error] 	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:89)
[error] 	at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:70)
[error] 	at com.amazonaws.internal.InstanceMetadataServiceResourceFetcher.readResource(InstanceMetadataServiceResourceFetcher.java:75)
[error] 	at com.amazonaws.internal.EC2ResourceFetcher.readResource(EC2ResourceFetcher.java:66)
[error] 	at com.amazonaws.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:407)
[error] 	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:376)
[error] 	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:372)
[error] 	at com.amazonaws.util.EC2MetadataUtils.getEC2InstanceRegion(EC2MetadataUtils.java:287)
[error] 	at com.amazonaws.regions.Regions.getCurrentRegion(Regions.java:109)
```