### PR TITLE
Cleanup LocalStack usage for scripted when secrets don't exist in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
           - sbt: 1.2.8
             java: 17
     name: Scripted - SBT ${{ matrix.sbt }}, Java ${{ matrix.Java }} (${{ matrix.os }})
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Java
@@ -68,51 +71,42 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      
-      #
-      # Test using S3 if we can access the secrets
-      #
 
-      # This will publishLocal for all crossSbtVersions then test example apps
-      # using the matrix.sbt version. For example we will publish the 0.13 and
-      # 1.0 compatible versions of the plugin (via our configured
-      # crossSbtVersions) and then test using a wider range of SBT versions.
-      - run: sbt -v ^publishLocal ^^${{ matrix.sbt }} scripted
-        if: ${{ github.event_name == 'push' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-      
       #
-      # Test using LocalStack if no access to secrets
+      # Use LocalStack if no access to secrets
+      #   Notes:
+      #     - Seems to want Path Style Access (which is deprecated in AWS S3)
+      #     - Seems to want the service endpoint to contain the bucket name (even with path style access)
       #
-      
       - name: Start LocalStack
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ env.AWS_ACCESS_KEY_ID == '' || env.AWS_SECRET_KEY == '' }}
         run: |
-          # install LocalStack cli and awslocal
+          # Set LocalStack environment variables for next step (e.g. 'sbt scripted')
+          echo "AWS_ACCESS_KEY_ID=test" >> $GITHUB_ENV
+          echo "AWS_SECRET_KEY=test" >> $GITHUB_ENV
+          echo "S3_PATH_STYLE_ACCESS=true" >> $GITHUB_ENV
+          echo "S3_SERVICE_ENDPOINT=http://fm-sbt-s3-resolver-example-bucket.s3.us-west-2.localhost.localstack.cloud:4566" >> $GITHUB_ENV
+          echo "S3_SIGNING_REGION=us-west-2" >> $GITHUB_ENV
+
+          # Install LocalStack cli and awslocal
           pip install localstack awscli-local[ver1]
+
           # Make sure to pull the latest version of the image
           docker pull localstack/localstack
+
           # Start LocalStack in the background
           SERVICES=s3 localstack start -d
+
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "LocalStack Startup complete"
-          awslocal s3api create-bucket --bucket fm-sbt-s3-resolver-example-bucket
+
+          # Create unit tests s3 bucket
+          AWS_ACCESS_KEY_ID=test AWS_SECRET_KEY=test awslocal s3api create-bucket --bucket fm-sbt-s3-resolver-example-bucket
+
       # This will publishLocal for all crossSbtVersions then test example apps
-      # using the matrix.sbt version. For example we will publish the 0.13 and
+      # using the matrix.sbt version. For example, we will publish the 0.13 and
       # 1.0 compatible versions of the plugin (via our configured
       # crossSbtVersions) and then test using a wider range of SBT versions.
       - run: sbt -v ^publishLocal ^^${{ matrix.sbt }} scripted
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          # LocalStack Notes:
-          #  - Seems to want Path Style Access (which is deprecated in AWS S3)
-          #  - Seems to want the service endpoint to contain the bucket name (even with path style access)
-          AWS_ACCESS_KEY_ID: test
-          AWS_SECRET_KEY: test
-          S3_PATH_STYLE_ACCESS: true
-          S3_SERVICE_ENDPOINT: http://fm-sbt-s3-resolver-example-bucket.s3.us-west-2.localhost.localstack.cloud:4566
-          S3_SIGNING_REGION: us-west-2


### PR DESCRIPTION
The existing GitHub Actions workflow fails when pushing a branch to any non-tpunder repo.

This simplifies the workflow and just uses LocalStack if the secrets aren't defined for any given push/branch/etc.